### PR TITLE
Use /4/ instead of /boomerang/ in paths

### DIFF
--- a/source/includes/global/_authentication.md
+++ b/source/includes/global/_authentication.md
@@ -28,7 +28,7 @@ You can manage your Access Tokens from your account. You can have multiple Acces
 
 ```shell
 curl --request GET \
-  --url 'https://example.booqable.com/api/boomerang/customers' \
+  --url 'https://example.booqable.com/api/4/customers' \
   --header 'Authorization: Bearer 9bcabeaa827810ad6383d2e15feab2d0c7d039093e22fdd955f11fe83437a32a'
 ```
 
@@ -68,7 +68,7 @@ You can have multiple authentication methods active at one time.
 request_method = 'POST'
 
 # Encoded request params
-fullpath = '/api/boomerang/orders/?filter%5Bcreated_at%5D%5Bgte%5D%3D1231232131132'
+fullpath = '/api/4/orders/?filter%5Bcreated_at%5D%5Bgte%5D%3D1231232131132'
 
 # Base64 encoded SHA256 body
 body = '{"note":"Let me in!"}'
@@ -118,7 +118,7 @@ Base64(
 
 ```shell
 curl --request GET \
-  --url 'https://example.booqable.com/api/boomerang/customers' \
+  --url 'https://example.booqable.com/api/4/customers' \
   --header 'Authorization: Bearer eyJraWQiOiIwZTJkM2I2YS00OTU0LTQyZTItYTAyNS1kYjMzODE1ZDU2YzUiLCJraW5kIjoic2luZ2xlX3VzZSIsImFsZyI6IkVTMjU2In0.eyJpc3MiOiJodHRwOi8vY29tcGFueS1uYW1lLmJvb3FhYmxlLmNvbSIsInN1YiI6IjVlMWViZmFmLWM5YmEtNDMyOC1hM2U1LThlNzNmZGQ1NGNiOSIsImF1ZCI6IjE4ZGI4YTE0LThhYzctNDE1OS05NmJkLTMxMzI0NmRhYTExMCIsImV4cCI6MTYzNTk0ODk3MiwiaWF0IjoxNjM1OTQ4MzcyLCJqdGkiOiJmMTNkZjNlOC0zMWNjLTQxYTUtOWVlNy1mZjgzMTdmNWQ0Y2EuVUU5VFZDNHZQMlpwYkhSbGNpVTFRbU55WldGMFpXUmZZWFFsTlVRbE5VSm5kR1VsTlVRbE0wUXhNak14TWpNeU1UTXhNVE15TGpWemNGcEhSak5IZFdVeVoycFZRVVZ3ZUhsVll6VTVVbTlIZW5sb2NHMXNWbVo0WlVGNVRrSlZUazA5In0.7S2eI3R6meFPPgZ5iyZQOsTDBHRCihKozKMjvIrNHeYoEsxzKltQhGjb2rnfSlpGrCL38-ub-FTs5EXP39rJfw
 ```
 

--- a/source/includes/global/_introduction.md
+++ b/source/includes/global/_introduction.md
@@ -15,7 +15,7 @@ The Booqable API is a RESTful [JSON API](https://jsonapi.org/) as such is design
 All API requests need to be directed to the correct company-specific endpoint.
 The format is as follows:
 
-`https://{company_slug}.booqable.com/api/boomerang/`
+`https://{company_slug}.booqable.com/api/4/`
 
 <aside class="notice">
   You must replace <code>{company_slug}</code> with the name of your company.
@@ -33,7 +33,7 @@ You can, however, also request data in nested structure by appending `.json` to 
 > A typical JSON API response:
 
 ```
-GET /api/boomerang/orders?include=customer
+GET /api/4/orders?include=customer
 ```
 
 ```json
@@ -49,7 +49,7 @@ GET /api/boomerang/orders?include=customer
       "relationships": {
         "customer": {
           "links": {
-            "related": "api/boomerang/customers/24e54970-7473-49a9-a71a-8c07eb97e510"
+            "related": "api/4/customers/24e54970-7473-49a9-a71a-8c07eb97e510"
           },
           "data": {
             "type": "customers",
@@ -69,16 +69,16 @@ GET /api/boomerang/orders?include=customer
       "relationships": {
         "properties": {
           "links": {
-            "related": "api/boomerang/properties?filter[owner_id]=24e54970-7473-49a9-a71a-8c07eb97e510&filter[owner_type]=Customer"
+            "related": "api/4/properties?filter[owner_id]=24e54970-7473-49a9-a71a-8c07eb97e510&filter[owner_type]=Customer"
           }
         }
       }
     }
   ],
   "links": {
-    "self": "api/boomerang/orders?fields%5Bcustomer%5D=name&fields%5Borders%5D=starts_at%2Cstops_at&include=customer&page%5Bnumber%5D=1&page%5Bsize%5D=25",
-    "first": "api/boomerang/orders?fields%5Bcustomer%5D=name&fields%5Borders%5D=starts_at%2Cstops_at&include=customer&page%5Bnumber%5D=1&page%5Bsize%5D=25",
-    "last": "api/boomerang/orders?fields%5Bcustomer%5D=name&fields%5Borders%5D=starts_at%2Cstops_at&include=customer&page%5Bnumber%5D=1&page%5Bsize%5D=25"
+    "self": "api/4/orders?fields%5Bcustomer%5D=name&fields%5Borders%5D=starts_at%2Cstops_at&include=customer&page%5Bnumber%5D=1&page%5Bsize%5D=25",
+    "first": "api/4/orders?fields%5Bcustomer%5D=name&fields%5Borders%5D=starts_at%2Cstops_at&include=customer&page%5Bnumber%5D=1&page%5Bsize%5D=25",
+    "last": "api/4/orders?fields%5Bcustomer%5D=name&fields%5Borders%5D=starts_at%2Cstops_at&include=customer&page%5Bnumber%5D=1&page%5Bsize%5D=25"
   },
   "meta": {}
 }
@@ -87,7 +87,7 @@ GET /api/boomerang/orders?include=customer
 > A JSON response:
 
 ```
-GET /api/boomerang/orders.json?include=customer
+GET /api/4/orders.json?include=customer
 ```
 
 ```json
@@ -146,7 +146,7 @@ Collections returned in list requests can be filtered on specific fields; filter
 > How to filter a request:
 
 ```
-/api/boomerang/orders?filter[starts_at][gte]=1980-11-16T09:00:00+00:00&filter[starts_at][lte]=1990-11-16T09:00:00+00:00&filter[status]=reserved
+/api/4/orders?filter[starts_at][gte]=1980-11-16T09:00:00+00:00&filter[starts_at][lte]=1990-11-16T09:00:00+00:00&filter[status]=reserved
 ```
 
 
@@ -161,7 +161,7 @@ The Booqable API consists of many resources related to each other. Therefore the
 > Including associated data:
 
 ```
-GET api/boomerang/orders?include=customer,customer.properties
+GET api/4/orders?include=customer,customer.properties
 ```
 
 ```json
@@ -176,7 +176,7 @@ GET api/boomerang/orders?include=customer,customer.properties
     "relationships": {
       "customer": {
         "links": {
-          "related": "api/boomerang/customers/404021af-c889-4d72-9296-481640f4c750"
+          "related": "api/4/customers/404021af-c889-4d72-9296-481640f4c750"
         },
         "data": {
           "type": "customers",
@@ -195,7 +195,7 @@ GET api/boomerang/orders?include=customer,customer.properties
       "relationships": {
         "properties": {
           "links": {
-            "related": "api/boomerang/properties?filter[owner_id]=404021af-c889-4d72-9296-481640f4c750&filter[owner_type]=Customer"
+            "related": "api/4/properties?filter[owner_id]=404021af-c889-4d72-9296-481640f4c750&filter[owner_type]=Customer"
           },
           "data": [
             {
@@ -216,7 +216,7 @@ GET api/boomerang/orders?include=customer,customer.properties
       "relationships": {
         "owner": {
           "links": {
-            "related": "api/boomerang/customers/404021af-c889-4d72-9296-481640f4c750"
+            "related": "api/4/customers/404021af-c889-4d72-9296-481640f4c750"
           }
         }
       }


### PR DESCRIPTION
"boomerang" is the project name
we want the documentation to use "4" as part of paths/urls