### PR TITLE
Revert "Remove v1/plannings#delete"

### DIFF
--- a/source/includes/v1/_planning.md
+++ b/source/includes/v1/_planning.md
@@ -14,3 +14,18 @@
 | charge_length       | Integer  | Length of the price charge in seconds         |
 | created_at          | DateTime | `Readonly` When the planning was created      |
 | updated_at          | DateTime | `Readonly` When the planning was last updated |
+
+## Delete a planning
+
+> Example request
+
+```shell
+curl --request DELETE \
+  --url 'https://example.booqable.com/api/1/orders/ea024c26-c322-485b-85ad-f67b890e5346/plannings/b649dcc8-2c93-45bd-88f3-35e1a8be8356'
+```
+
+Deletes a planning from an order.
+
+### HTTP Request
+
+`DELETE /orders/:order_id/plannings/:id`


### PR DESCRIPTION
Still used as nested route under `api/1/orders/:order_id/plannings/:planning_id`

Reverts booqable/boomerang-api-documentation#352