### PR TITLE
Fix sidebar misalignment

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -405,6 +405,10 @@ ul#toc {
     @extend %left-col;
   }
 
+  &>h3, &>h4, &>h5, &>h6 {
+    clear: right;
+  }
+
   &>figure {
     margin-right: $examples-width + 5%;
     padding-block-end: 2rem;


### PR DESCRIPTION
Fix contents of the right sidebar appearing too high or too low on the page, compared to the main page body content. Especially prevalent in the apps documentation page. Still not perfect though, but at least the main body content "waits" for the sidebar content to finish.

---

**Before:**
<img width="1148" height="1492" alt="before" src="https://github.com/user-attachments/assets/1413f960-e54f-435e-8138-d1d775196248" />

**After:**
<img width="1148" height="1445" alt="after" src="https://github.com/user-attachments/assets/45c75362-cb62-4056-ae8a-bf7cbcbcb18d" />
