### PR TITLE
Locations: Remove clusters from API docs

### DIFF
--- a/source/includes/v4/resources/_locations.md
+++ b/source/includes/v4/resources/_locations.md
@@ -115,7 +115,7 @@ Name | Description
 -- | --
 `fields[]` | **array** <br>List of comma separated fields to include instead of the default fields. `?fields[locations]=created_at,updated_at,archived`
 `filter` | **hash** <br>The filters to apply `?filter[attribute][eq]=value`
-`include` | **string** <br>List of comma seperated relationships to sideload. `?include=carriers`
+`include` | **string** <br>List of comma separated relationships to sideload. `?include=carriers`
 `meta` | **hash** <br>Metadata to send along. `?meta[total][]=count`
 `page[number]` | **string** <br>The page to request.
 `page[size]` | **string** <br>The amount of items per page.
@@ -228,7 +228,7 @@ This request accepts the following parameters:
 Name | Description
 -- | --
 `fields[]` | **array** <br>List of comma separated fields to include instead of the default fields. `?fields[locations]=created_at,updated_at,archived`
-`include` | **string** <br>List of comma seperated relationships to sideload. `?include=carriers`
+`include` | **string** <br>List of comma separated relationships to sideload. `?include=carriers`
 
 
 ### Includes
@@ -327,7 +327,7 @@ This request accepts the following parameters:
 Name | Description
 -- | --
 `fields[]` | **array** <br>List of comma separated fields to include instead of the default fields. `?fields[locations]=created_at,updated_at,archived`
-`include` | **string** <br>List of comma seperated relationships to sideload. `?include=carriers`
+`include` | **string** <br>List of comma separated relationships to sideload. `?include=carriers`
 
 
 ### Request body
@@ -440,7 +440,7 @@ This request accepts the following parameters:
 Name | Description
 -- | --
 `fields[]` | **array** <br>List of comma separated fields to include instead of the default fields. `?fields[locations]=created_at,updated_at,archived`
-`include` | **string** <br>List of comma seperated relationships to sideload. `?include=carriers`
+`include` | **string** <br>List of comma separated relationships to sideload. `?include=carriers`
 
 
 ### Request body

--- a/source/includes/v4/resources/_locations.md
+++ b/source/includes/v4/resources/_locations.md
@@ -115,7 +115,7 @@ Name | Description
 -- | --
 `fields[]` | **array** <br>List of comma separated fields to include instead of the default fields. `?fields[locations]=created_at,updated_at,archived`
 `filter` | **hash** <br>The filters to apply `?filter[attribute][eq]=value`
-`include` | **string** <br>List of comma seperated relationships to sideload. `?include=clusters,carriers`
+`include` | **string** <br>List of comma seperated relationships to sideload. `?include=carriers`
 `meta` | **hash** <br>Metadata to send along. `?meta[total][]=count`
 `page[number]` | **string** <br>The page to request.
 `page[size]` | **string** <br>The amount of items per page.
@@ -155,7 +155,6 @@ This request accepts the following includes:
 
 <ul>
   <li><code>carriers</code></li>
-  <li><code>clusters</code></li>
 </ul>
 
 
@@ -229,7 +228,7 @@ This request accepts the following parameters:
 Name | Description
 -- | --
 `fields[]` | **array** <br>List of comma separated fields to include instead of the default fields. `?fields[locations]=created_at,updated_at,archived`
-`include` | **string** <br>List of comma seperated relationships to sideload. `?include=clusters,carriers`
+`include` | **string** <br>List of comma seperated relationships to sideload. `?include=carriers`
 
 
 ### Includes
@@ -238,7 +237,6 @@ This request accepts the following includes:
 
 <ul>
   <li><code>carriers</code></li>
-  <li><code>clusters</code></li>
 </ul>
 
 
@@ -329,7 +327,7 @@ This request accepts the following parameters:
 Name | Description
 -- | --
 `fields[]` | **array** <br>List of comma separated fields to include instead of the default fields. `?fields[locations]=created_at,updated_at,archived`
-`include` | **string** <br>List of comma seperated relationships to sideload. `?include=clusters,carriers`
+`include` | **string** <br>List of comma seperated relationships to sideload. `?include=carriers`
 
 
 ### Request body
@@ -359,7 +357,6 @@ This request accepts the following includes:
 
 <ul>
   <li><code>carriers</code></li>
-  <li><code>clusters</code></li>
 </ul>
 
 
@@ -443,7 +440,7 @@ This request accepts the following parameters:
 Name | Description
 -- | --
 `fields[]` | **array** <br>List of comma separated fields to include instead of the default fields. `?fields[locations]=created_at,updated_at,archived`
-`include` | **string** <br>List of comma seperated relationships to sideload. `?include=clusters,carriers`
+`include` | **string** <br>List of comma seperated relationships to sideload. `?include=carriers`
 
 
 ### Request body
@@ -473,7 +470,6 @@ This request accepts the following includes:
 
 <ul>
   <li><code>carriers</code></li>
-  <li><code>clusters</code></li>
 </ul>
 
 


### PR DESCRIPTION
Clusters no longer exist as a concept, so I'm removing all references from the Locations resource documentation.